### PR TITLE
Adds Titiler helm charts and helm release Github action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.5.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -6,4 +6,22 @@ The eventual goal is to move this repository under the [developmentseed](https:/
 
 ## Usage
 
-Visit https://element84.github.io/titiler-helm-charts/ for installation instructions.
+[Helm](https://helm.sh) must be installed to use the charts.  Please refer to
+Helm's [documentation](https://helm.sh/docs) to get started.
+
+Once Helm is installed you can install Titiler by running the following commands:
+
+```bash
+cd charts/titiler
+helm install titiler .
+```
+
+Visit https://element84.github.io/titiler-helm-charts/ for installation instructions if you prefer to install this service via a Helm repository.
+
+Once installed you can verify Titiler is running by first configuring port forwarding from the Titiler pod:
+
+```bash
+kubectl port-forward {TITILER_POD_NAME} 3000:80
+```
+
+Then with your browser of choice navigate to `http://localhost:3000`.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
-# titiler-helm-charts
-A public Helm repository hosting Titiler helm charts.
+# Titiler Helm Charts
+
+A public Helm repository hosting Titiler helm charts. This repository hosts the Helm charts found in the deployments directory of the [Titiler](https://github.com/developmentseed/titiler) repository. We're currently hosting them in a separate repository because the development repository does not host as a Helm repository and therefore can't easily be pulled into a different project.
+
+The eventual goal is to move this repository under the [developmentseed](https://github.com/developmentseed) organization.
+
+## Usage
+
+Visit https://element84.github.io/titiler-helm-charts/ for installation instructions.

--- a/charts/titiler/.helmignore
+++ b/charts/titiler/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/titiler/Chart.yaml
+++ b/charts/titiler/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+appVersion: 0.11.5
+description: A dynamic Web Map tile server
+name: titiler
+version: 1.1.0
+icon: https://raw.githubusercontent.com/developmentseed/titiler/main/docs/logos/TiTiler_logo_small.png
+maintainers:
+  - name: emmanuelmathot  # Emmanuel Mathot
+    url: https://github.com/emmanuelmathot

--- a/charts/titiler/ci/default-values.yaml
+++ b/charts/titiler/ci/default-values.yaml
@@ -1,0 +1,5 @@
+replicaCount: 1
+
+image:
+  repository: titiler
+  tag: dev

--- a/charts/titiler/templates/NOTES.txt
+++ b/charts/titiler/templates/NOTES.txt
@@ -1,0 +1,21 @@
+1. Get the Titile docs deployed here:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}docs
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "titiler.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT/docs
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "titiler.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "titiler.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "titiler.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080/docs to use Titiler"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:80
+{{- end }}

--- a/charts/titiler/templates/_helpers.tpl
+++ b/charts/titiler/templates/_helpers.tpl
@@ -1,0 +1,52 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "titiler.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "titiler.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "titiler.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "titiler.labels" -}}
+helm.sh/chart: {{ include "titiler.chart" . }}
+{{ include "titiler.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "titiler.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "titiler.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/titiler/templates/configmap.yaml
+++ b/charts/titiler/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "titiler.fullname" . }}-configmap
+data:
+  {{- if .Values.netrc }}
+  netrc: {{ tpl (.Values.netrc) . | quote }}
+  {{- end }}
+    

--- a/charts/titiler/templates/deployment.yaml
+++ b/charts/titiler/templates/deployment.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "titiler.fullname" . }}
+  labels:
+    {{- include "titiler.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "titiler.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "titiler.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+          {{- range $key, $val := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $val | quote }}
+          {{- end }}
+          {{- if .Values.netrc }}
+            - name: NETRC
+              value: /config/netrc
+            - name: CURLOPT_NETRC
+              value: CURL_NETRC_OPTIONAL
+            - name: CURLOPT_NETRC_FILE
+              value: /config/netrc
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.env.PORT }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - mountPath: /config
+              name: config
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "titiler.fullname" . }}-configmap
+      {{- with .Values.serviceAccountName }}
+      serviceAccountName: {{ . | quote }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/charts/titiler/templates/ingress.yaml
+++ b/charts/titiler/templates/ingress.yaml
@@ -1,0 +1,59 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "titiler.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/titiler/templates/service.yaml
+++ b/charts/titiler/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "titiler.fullname" . }}
+  labels:
+    {{- include "titiler.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "titiler.selectorLabels" . | nindent 4 }}

--- a/charts/titiler/values-test.yaml
+++ b/charts/titiler/values-test.yaml
@@ -1,0 +1,44 @@
+# Default values for titiler.
+replicaCount: 4
+
+ingress:
+  enabled: true
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: titiler.charter.uat.esaportal.eu
+      paths: ["/"]
+  tls:
+   - secretName: domain-tls
+     hosts:
+       - titiler.charter.uat.esaportal.eu
+
+env:
+  PORT: 80
+  CPL_TMPDIR: /tmp
+  GDAL_CACHEMAX: 75%
+  VSI_CACHE: TRUE
+  VSI_CACHE_SIZE: 1073741824
+  GDAL_DISABLE_READDIR_ON_OPEN: EMPTY_DIR
+  GDAL_HTTP_MERGE_CONSECUTIVE_RANGES: YES
+  GDAL_HTTP_MULTIPLEX: YES
+  GDAL_HTTP_VERSION: 2
+  PYTHONWARNINGS: ignore
+  WEB_CONCURRENCY: 2
+
+resources:
+   limits:
+    cpu: 256m
+    memory: 1Gi
+    # ephemeral-storage: 10Gi
+   requests:
+    cpu: 256m
+    memory: 1Gi
+    # ephemeral-storage: 10Gi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/charts/titiler/values.yaml
+++ b/charts/titiler/values.yaml
@@ -1,0 +1,56 @@
+# Default values for titiler.
+replicaCount: 1
+
+image:
+  repository: ghcr.io/developmentseed/titiler-uvicorn
+  tag: latest
+  pullPolicy: IfNotPresent
+
+nameOverride: ""
+fullnameOverride: ""
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: titiler.local
+      paths: ["/"]
+  tls: []
+  #  - secretName: titiler-tls
+  #    hosts:
+  #      - titiler.local
+
+env:
+  PORT: 80
+  CPL_TMPDIR: /tmp
+  GDAL_CACHEMAX: 200  # 200 mb
+  VSI_CACHE: "TRUE"
+  VSI_CACHE_SIZE: 5000000  # 5 MB (per file-handle)
+  GDAL_DISABLE_READDIR_ON_OPEN: "EMPTY_DIR"
+  GDAL_HTTP_MERGE_CONSECUTIVE_RANGES: "YES"
+  GDAL_HTTP_MULTIPLEX: "YES"
+  GDAL_HTTP_VERSION: 2
+  PYTHONWARNINGS: "ignore"
+  WEB_CONCURRENCY: 2
+
+resources:
+  limits:
+    cpu: 1
+    memory: 2Gi
+  requests:
+    cpu: 1
+    memory: 2Gi
+
+serviceAccountName: ""
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
This PR adds the Titiler helm chart and the Github action (https://helm.sh/docs/howto/chart_releaser_action/) that packages and creates a release whenever the chart is updated.

I also created the `gh-pages` branch based on the instructions in the above link and updated the README on that branch to include instructions on how to install the titiler chart (https://github.com/Element84/titiler-helm-charts/tree/gh-pages).